### PR TITLE
:sparkles: Add an auto-injected DockerClientFacade field to Specs (#6)

### DIFF
--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerClientFacade.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerClientFacade.groovy
@@ -8,7 +8,7 @@ class DockerClientFacade {
     DockerClient dockerClient
     String image
     Map clientSpecificContainerConfig
-    def containerStatus
+    def containerHandle
 
     DockerClientFacade(Docker containerConfig) {
         image = containerConfig.image()
@@ -17,14 +17,22 @@ class DockerClientFacade {
     }
 
     void startContainer() {
-        containerStatus = dockerClient.run(image, clientSpecificContainerConfig, "latest")
+        containerHandle = dockerClient.run(image, clientSpecificContainerConfig, "latest")
     }
 
     void stopContainer() {
-        def id = containerStatus.container.content.Id
+        def id = containerId()
 
         dockerClient.stop(id)
         dockerClient.rm(id)
     }
 
+    private String containerId() {
+        containerHandle.container.content.Id
+    }
+
+    String getContainerIp() {
+        def containerInspection = dockerClient.inspectContainer(containerId())
+        return containerInspection.content.NetworkSettings.Networks.bridge.IPAddress
+    }
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerExtension.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerExtension.groovy
@@ -1,6 +1,7 @@
 package com.groovycoder.spockdockerextension
 
 import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.model.FieldInfo
 import org.spockframework.runtime.model.SpecInfo
 
 class DockerExtension extends AbstractAnnotationDrivenExtension<Docker> {
@@ -9,4 +10,6 @@ class DockerExtension extends AbstractAnnotationDrivenExtension<Docker> {
     void visitSpecAnnotation(Docker annotation, SpecInfo spec) {
         spec.addInterceptor(new DockerMethodInterceptor(annotation))
     }
+
+
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerMethodInterceptor.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerMethodInterceptor.groovy
@@ -2,6 +2,7 @@ package com.groovycoder.spockdockerextension
 
 import org.spockframework.runtime.extension.AbstractMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FieldInfo
 
 class DockerMethodInterceptor extends AbstractMethodInterceptor {
 
@@ -17,8 +18,21 @@ class DockerMethodInterceptor extends AbstractMethodInterceptor {
 
     @Override
     void interceptSpecExecution(IMethodInvocation invocation) throws Throwable {
+
+        injectDockerFacade(invocation)
+
         dockerClient.startContainer()
         invocation.proceed()
         dockerClient.stopContainer()
+    }
+
+    private void injectDockerFacade(IMethodInvocation invocation) {
+        def spec = invocation.getSpec()
+
+        spec.getAllFields().find { FieldInfo field ->
+            if (field.type == DockerClientFacade) {
+                field.writeValue(invocation.instance, dockerClient)
+            }
+        }
     }
 }

--- a/src/test/groovy/com/groovycoder/spockdockerextension/DockerClientFacadeIT.groovy
+++ b/src/test/groovy/com/groovycoder/spockdockerextension/DockerClientFacadeIT.groovy
@@ -13,6 +13,10 @@ class DockerClientFacadeIT extends Specification {
     @Shared
     DockerClientFacade dockerClientFacade
 
+    def cleanupSpec() {
+        dockerClientFacade.stopContainer()
+    }
+
     def "should start specified docker container"() {
         given: "a docker container config"
         Docker config = Stub(Docker)
@@ -33,6 +37,11 @@ class DockerClientFacadeIT extends Specification {
 
         then: "docker container is running and returns http status code 200"
         response.statusLine.statusCode == 200
+    }
+
+    def "ip of container is accessible"() {
+        expect:
+        dockerClientFacade.getContainerIp().matches('^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\$')
     }
 
     def "should stop running docker container"() {

--- a/src/test/groovy/com/groovycoder/spockdockerextension/DockerExtensionIT.groovy
+++ b/src/test/groovy/com/groovycoder/spockdockerextension/DockerExtensionIT.groovy
@@ -2,10 +2,20 @@ package com.groovycoder.spockdockerextension
 
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClientBuilder
+import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Stepwise
 
+@Stepwise
 @Docker(image = "emilevauge/whoami", ports = ["8080:80", "8081:80"])
 class DockerExtensionIT extends Specification {
+
+    @Shared
+    DockerClientFacade dockerClientFacade
+
+    def setup() {
+        println ""
+    }
 
     def "should start accessible docker container"() {
         given: "a http client"
@@ -20,6 +30,21 @@ class DockerExtensionIT extends Specification {
         then: "docker container is running and returns http status code 200"
         response1.statusLine.statusCode == 200
         response2.statusLine.statusCode == 200
+    }
+
+    def "should be able to access to docker container via its ip"() {
+        given: "a http client"
+        def client = HttpClientBuilder.create().build()
+
+        when: "retrieving the ip of the container"
+        def ip = dockerClientFacade.containerIp
+
+        and: "accessing web server"
+        def response1 = client.execute(new HttpGet("http://$ip:80"))
+
+        then: "docker container is running and returns http status code 200"
+        response1.statusLine.statusCode == 200
+
     }
 
 }

--- a/src/test/groovy/com/groovycoder/spockdockerextension/DockerMethodInterceptorTest.groovy
+++ b/src/test/groovy/com/groovycoder/spockdockerextension/DockerMethodInterceptorTest.groovy
@@ -1,6 +1,7 @@
 package com.groovycoder.spockdockerextension
 
 import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.SpecInfo
 import spock.lang.Specification
 
 class DockerMethodInterceptorTest extends Specification {
@@ -14,6 +15,9 @@ class DockerMethodInterceptorTest extends Specification {
 
         and: "the method invocation"
         def methodInvocationMock = Mock(IMethodInvocation)
+        def specStub = Stub(SpecInfo)
+        methodInvocationMock.spec >> specStub
+        specStub.allFields >> []
 
         when: "intercepting the spec"
         interceptor.interceptSpecExecution(methodInvocationMock)


### PR DESCRIPTION
Also add the possibility to access inspection properties of the currently running container, like IP adress.
Provides the groundwork for #6.