### PR TITLE
#12 container handles for test code using@docker compose

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,4 +16,7 @@ dependencies {
     testCompile group: 'cglib', name: 'cglib-nodep', version: '3.2.4'
     testCompile group: 'org.objenesis', name: 'objenesis', version: '2.4'
     testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
+    // https://mvnrepository.com/artifact/org.slf4j/log4j-over-slf4j
+    testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.22'
+
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerCompose.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerCompose.groovy
@@ -15,6 +15,9 @@ import java.lang.annotation.Target
     /**
      * @return path to the docker-compose file
      */
-    String value()
+    String composeFile()
 
+    Expose[] exposedServicePorts() default []
+
+    boolean shared() default false
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeExtension.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeExtension.groovy
@@ -6,7 +6,6 @@ import org.spockframework.runtime.model.SpecInfo
 
 class DockerComposeExtension extends AbstractAnnotationDrivenExtension<DockerCompose> {
 
-
     @Override
     void visitFeatureAnnotation(DockerCompose annotation, FeatureInfo feature) {
         feature.addInterceptor(new DockerComposeMethodInterceptor(annotation))
@@ -14,7 +13,11 @@ class DockerComposeExtension extends AbstractAnnotationDrivenExtension<DockerCom
 
     @Override
     void visitSpecAnnotation(DockerCompose annotation, SpecInfo spec) {
-        spec.addInterceptor(new DockerComposeMethodInterceptor(annotation))
-    }
+        def interceptor = new DockerComposeMethodInterceptor(annotation)
+        spec.addSetupInterceptor(interceptor)
+        spec.addCleanupInterceptor(interceptor)
+        spec.addSetupSpecInterceptor(interceptor)
+        spec.addCleanupSpecInterceptor(interceptor)
 
+    }
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeExtension.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeExtension.groovy
@@ -1,5 +1,6 @@
 package com.groovycoder.spockdockerextension
 
+import org.spockframework.runtime.InvalidSpecException
 import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
 import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.SpecInfo
@@ -8,16 +9,26 @@ class DockerComposeExtension extends AbstractAnnotationDrivenExtension<DockerCom
 
     @Override
     void visitFeatureAnnotation(DockerCompose annotation, FeatureInfo feature) {
-        feature.addInterceptor(new DockerComposeMethodInterceptor(annotation))
+        if (annotation.shared()) {
+            throw new InvalidSpecException("@%s with shared = true may not be applied to feature methods")
+                    .withArgs(DockerCompose.getSimpleName())
+        }
+        def interceptor = new DockerComposeMethodInterceptor(annotation, feature)
+        def spec = feature.spec
+
+        spec.addSetupInterceptor(interceptor)
+        spec.addCleanupInterceptor(interceptor)
     }
 
     @Override
     void visitSpecAnnotation(DockerCompose annotation, SpecInfo spec) {
         def interceptor = new DockerComposeMethodInterceptor(annotation)
-        spec.addSetupInterceptor(interceptor)
-        spec.addCleanupInterceptor(interceptor)
-        spec.addSetupSpecInterceptor(interceptor)
-        spec.addCleanupSpecInterceptor(interceptor)
-
+        if (annotation.shared()) {
+            spec.addSetupSpecInterceptor(interceptor)
+            spec.addCleanupSpecInterceptor(interceptor)
+        } else {
+            spec.addSetupInterceptor(interceptor)
+            spec.addCleanupInterceptor(interceptor)
+        }
     }
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeMethodInterceptor.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeMethodInterceptor.groovy
@@ -3,13 +3,21 @@ package com.groovycoder.spockdockerextension
 import com.groovycoder.spockdockerextension.docker.DockerComposeFacade
 import org.spockframework.runtime.extension.AbstractMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FieldInfo
 
 class DockerComposeMethodInterceptor extends AbstractMethodInterceptor {
 
     private final DockerComposeFacade dockerComposeClient
+    private final isShared
 
     DockerComposeMethodInterceptor(DockerCompose dockerCompose) {
-        this.dockerComposeClient = new DockerComposeFacade(dockerCompose.value())
+        def composeFile = dockerCompose.composeFile()
+        def servicePorts = dockerCompose.exposedServicePorts()
+        this.isShared = dockerCompose.shared()
+        def exposedServiceInstances = servicePorts.collect({
+            new ExposedServiceInstance(it.service(), it.port(), it.instance())
+        })
+        this.dockerComposeClient = new DockerComposeFacade(composeFile, exposedServiceInstances)
     }
 
     @Override
@@ -22,9 +30,78 @@ class DockerComposeMethodInterceptor extends AbstractMethodInterceptor {
         wrapInvocationWithDockerComposeUpAndDown(invocation)
     }
 
-    private void wrapInvocationWithDockerComposeUpAndDown(IMethodInvocation invocation) {
+    @Override
+    void interceptSetupMethod(IMethodInvocation invocation) throws Throwable {
+        if (isShared) return
         dockerComposeClient.up()
-        invocation.proceed()
+        injectDockerFacade(invocation)
+    }
+
+    @Override
+    void interceptCleanupMethod(IMethodInvocation invocation) throws Throwable {
+        if (isShared) return
         dockerComposeClient.down()
+    }
+
+    @Override
+    void interceptSetupSpecMethod(IMethodInvocation invocation) throws Throwable {
+        if (!isShared) return
+        dockerComposeClient.up()
+        injectDockerFacade(invocation)
+    }
+
+    @Override
+    void interceptCleanupSpecMethod(IMethodInvocation invocation) throws Throwable {
+        if (!isShared) return
+        dockerComposeClient.down()
+    }
+
+    private void wrapInvocationWithDockerComposeUpAndDown(IMethodInvocation invocation) {
+        invocation.proceed()
+    }
+
+    private void injectDockerFacade(IMethodInvocation invocation) {
+        def spec = invocation.getSpec()
+
+        spec.getAllFields().each { FieldInfo field ->
+            injectIntoField(field, invocation)
+        }
+    }
+
+    private void injectIntoField(FieldInfo field, IMethodInvocation invocation) {
+        def fieldClass = field.type
+
+        switch (fieldClass) {
+            case DockerComposeFacade:
+                if (this.isShared && field.shared) {
+                    field.writeValue(invocation.sharedInstance, dockerComposeClient)
+                } else if (!this.isShared && !field.shared) {
+                    field.writeValue(invocation.instance, dockerComposeClient)
+                }
+                break
+            case Integer:
+                DockerComposeServicePort servicePortAnnotation = field.getAnnotation(DockerComposeServicePort)
+                if (servicePortAnnotation) {
+                    def port = dockerComposeClient.getServicePort(servicePortAnnotation.service(), servicePortAnnotation.port(), servicePortAnnotation.instance())
+                    if (this.isShared && field.shared) {
+                        field.writeValue(invocation.sharedInstance, port)
+                    } else if (!this.isShared && !field.shared) {
+                        field.writeValue(invocation.instance, port)
+                    }
+                }
+
+                break
+            case String:
+                DockerComposeServiceHost servicePortAnnotation = field.getAnnotation(DockerComposeServiceHost)
+                if (servicePortAnnotation) {
+                    def port = dockerComposeClient.getServiceHost(servicePortAnnotation.service(), servicePortAnnotation.port(), servicePortAnnotation.instance())
+                    if (this.isShared && field.shared) {
+                        field.writeValue(invocation.sharedInstance, port)
+                    } else if (!this.isShared && !field.shared) {
+                        field.writeValue(invocation.instance, port)
+                    }
+                }
+                break
+        }
     }
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeMethodInterceptor.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeMethodInterceptor.groovy
@@ -3,14 +3,16 @@ package com.groovycoder.spockdockerextension
 import com.groovycoder.spockdockerextension.docker.DockerComposeFacade
 import org.spockframework.runtime.extension.AbstractMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.FieldInfo
 
 class DockerComposeMethodInterceptor extends AbstractMethodInterceptor {
 
     private final DockerComposeFacade dockerComposeClient
-    private final isShared
+    private final boolean isShared
+    private final FeatureInfo feature
 
-    DockerComposeMethodInterceptor(DockerCompose dockerCompose) {
+    DockerComposeMethodInterceptor(DockerCompose dockerCompose, FeatureInfo feature) {
         def composeFile = dockerCompose.composeFile()
         def servicePorts = dockerCompose.exposedServicePorts()
         this.isShared = dockerCompose.shared()
@@ -18,53 +20,84 @@ class DockerComposeMethodInterceptor extends AbstractMethodInterceptor {
             new ExposedServiceInstance(it.service(), it.port(), it.instance())
         })
         this.dockerComposeClient = new DockerComposeFacade(composeFile, exposedServiceInstances)
+        this.feature = feature
     }
 
-    @Override
-    void interceptFeatureExecution(IMethodInvocation invocation) throws Throwable {
-        wrapInvocationWithDockerComposeUpAndDown(invocation)
-    }
-
-    @Override
-    void interceptSpecExecution(IMethodInvocation invocation) throws Throwable {
-        wrapInvocationWithDockerComposeUpAndDown(invocation)
+    DockerComposeMethodInterceptor(DockerCompose dockerCompose) {
+        this(dockerCompose, null)
     }
 
     @Override
     void interceptSetupMethod(IMethodInvocation invocation) throws Throwable {
-        if (isShared) return
-        dockerComposeClient.up()
-        injectDockerFacade(invocation)
+        if (invocationMatches(invocation)) {
+            dockerComposeClient.up()
+            injectIntoAllFieldsOfSpec(invocation)
+        }
+        invocation.proceed()
     }
 
     @Override
     void interceptCleanupMethod(IMethodInvocation invocation) throws Throwable {
-        if (isShared) return
-        dockerComposeClient.down()
+        if (invocationMatches(invocation)) {
+            dockerComposeClient.down()
+        }
+        invocation.proceed()
     }
 
     @Override
     void interceptSetupSpecMethod(IMethodInvocation invocation) throws Throwable {
-        if (!isShared) return
-        dockerComposeClient.up()
-        injectDockerFacade(invocation)
+        if (invocationMatches(invocation)) {
+            dockerComposeClient.up()
+            injectIntoAllFieldsOfSpec(invocation)
+        }
+        invocation.proceed()
     }
 
     @Override
     void interceptCleanupSpecMethod(IMethodInvocation invocation) throws Throwable {
-        if (!isShared) return
-        dockerComposeClient.down()
-    }
-
-    private void wrapInvocationWithDockerComposeUpAndDown(IMethodInvocation invocation) {
+        if (invocationMatches(invocation)) {
+            dockerComposeClient.down()
+        }
         invocation.proceed()
     }
 
-    private void injectDockerFacade(IMethodInvocation invocation) {
+    private boolean invocationMatches(IMethodInvocation invocation) {
+        if (feature == null) {
+            // this interceptor is not bound to a specific feature and thus matches
+            return true
+        }
+
+        if (feature == invocation.feature) {
+            // this interceptor is not bound to a specific feature which matches the feature of the invocation
+            return true
+        }
+
+        // this interceptor is bound to a specific feature but the invocation is for a different feature
+        return false
+    }
+
+    private void injectIntoAllFieldsOfSpec(IMethodInvocation invocation) {
         def spec = invocation.getSpec()
 
         spec.getAllFields().each { FieldInfo field ->
             injectIntoField(field, invocation)
+        }
+    }
+
+    /**
+     * Write to the {@link IMethodInvocation#getSharedInstance()} if this is a shared docker compose, otherwise write to {@link IMethodInvocation#getInstance()}
+     * @param field
+     * @param invocation
+     * @param value
+     */
+    private void writeSharedOrIsolated(FieldInfo field, IMethodInvocation invocation, Object value) {
+        final instance
+        if (this.isShared && field.shared) {
+            instance = invocation.sharedInstance
+            field.writeValue(instance, value)
+        } else if (!this.isShared && !field.shared) {
+            instance = invocation.instance
+            field.writeValue(instance, value)
         }
     }
 
@@ -73,33 +106,21 @@ class DockerComposeMethodInterceptor extends AbstractMethodInterceptor {
 
         switch (fieldClass) {
             case DockerComposeFacade:
-                if (this.isShared && field.shared) {
-                    field.writeValue(invocation.sharedInstance, dockerComposeClient)
-                } else if (!this.isShared && !field.shared) {
-                    field.writeValue(invocation.instance, dockerComposeClient)
-                }
+                writeSharedOrIsolated(field, invocation, dockerComposeClient)
                 break
             case Integer:
                 DockerComposeServicePort servicePortAnnotation = field.getAnnotation(DockerComposeServicePort)
                 if (servicePortAnnotation) {
                     def port = dockerComposeClient.getServicePort(servicePortAnnotation.service(), servicePortAnnotation.port(), servicePortAnnotation.instance())
-                    if (this.isShared && field.shared) {
-                        field.writeValue(invocation.sharedInstance, port)
-                    } else if (!this.isShared && !field.shared) {
-                        field.writeValue(invocation.instance, port)
-                    }
+                    writeSharedOrIsolated(field, invocation, port)
                 }
 
                 break
             case String:
-                DockerComposeServiceHost servicePortAnnotation = field.getAnnotation(DockerComposeServiceHost)
-                if (servicePortAnnotation) {
-                    def port = dockerComposeClient.getServiceHost(servicePortAnnotation.service(), servicePortAnnotation.port(), servicePortAnnotation.instance())
-                    if (this.isShared && field.shared) {
-                        field.writeValue(invocation.sharedInstance, port)
-                    } else if (!this.isShared && !field.shared) {
-                        field.writeValue(invocation.instance, port)
-                    }
+                DockerComposeServiceHost serviceHostAnnotation = field.getAnnotation(DockerComposeServiceHost)
+                if (serviceHostAnnotation) {
+                    def host = dockerComposeClient.getServiceHost(serviceHostAnnotation.service(), serviceHostAnnotation.port(), serviceHostAnnotation.instance())
+                    writeSharedOrIsolated(field, invocation, host)
                 }
                 break
         }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServiceHost.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServiceHost.groovy
@@ -1,0 +1,29 @@
+package com.groovycoder.spockdockerextension
+
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = ElementType.FIELD)
+@ExtensionAnnotation(DockerComposeServiceHostExtension)
+@interface DockerComposeServiceHost {
+
+    /**
+     * @return name of the image to start.
+     */
+    String service()
+
+    /**
+     * @return port bindings in docker CLI style syntax
+     */
+    int port()
+
+    /**
+     * @return name under which the container is accessible inside the tests (optional)
+     */
+    int instance() default 1
+}

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServiceHost.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServiceHost.groovy
@@ -23,7 +23,7 @@ import java.lang.annotation.Target
     int port()
 
     /**
-     * @return name under which the container is accessible inside the tests (optional)
+     * @return the referenced instance, defaults to 1
      */
     int instance() default 1
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServiceHostExtension.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServiceHostExtension.groovy
@@ -1,7 +1,11 @@
 package com.groovycoder.spockdockerextension
 
 import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.model.FieldInfo
 
 class DockerComposeServiceHostExtension extends AbstractAnnotationDrivenExtension<DockerComposeServiceHost> {
-    // TODO must this exist?
+    @Override
+    void visitFieldAnnotation(DockerComposeServiceHost annotation, FieldInfo field) {
+        // method must be overridden to allow spock access to the annotation
+    }
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServiceHostExtension.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServiceHostExtension.groovy
@@ -1,0 +1,7 @@
+package com.groovycoder.spockdockerextension
+
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+
+class DockerComposeServiceHostExtension extends AbstractAnnotationDrivenExtension<DockerComposeServiceHost> {
+    // TODO must this exist?
+}

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePort.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePort.groovy
@@ -1,0 +1,29 @@
+package com.groovycoder.spockdockerextension
+
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = ElementType.FIELD)
+@ExtensionAnnotation(DockerComposeServicePortExtension)
+@interface DockerComposeServicePort {
+
+    /**
+     * @return name of the image to start.
+     */
+    String service()
+
+    /**
+     * @return port bindings in docker CLI style syntax
+     */
+    int port()
+
+    /**
+     * @return name under which the container is accessible inside the tests (optional)
+     */
+    int instance() default 1
+}

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePort.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePort.groovy
@@ -8,8 +8,8 @@ import java.lang.annotation.RetentionPolicy
 import java.lang.annotation.Target
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(value = ElementType.FIELD)
 @ExtensionAnnotation(DockerComposeServicePortExtension)
+@Target(ElementType.FIELD)
 @interface DockerComposeServicePort {
 
     /**

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePort.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePort.groovy
@@ -23,7 +23,7 @@ import java.lang.annotation.Target
     int port()
 
     /**
-     * @return name under which the container is accessible inside the tests (optional)
+     * @return the referenced instance, defaults to 1
      */
     int instance() default 1
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePortExtension.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePortExtension.groovy
@@ -1,7 +1,11 @@
 package com.groovycoder.spockdockerextension
 
 import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.model.FieldInfo
 
 class DockerComposeServicePortExtension extends AbstractAnnotationDrivenExtension<DockerComposeServicePort> {
-    // TODO must this exist?
+    @Override
+    void visitFieldAnnotation(DockerComposeServicePort annotation, FieldInfo field) {
+        // method must be overridden to allow spock access to the annotation
+    }
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePortExtension.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/DockerComposeServicePortExtension.groovy
@@ -1,0 +1,7 @@
+package com.groovycoder.spockdockerextension
+
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+
+class DockerComposeServicePortExtension extends AbstractAnnotationDrivenExtension<DockerComposeServicePort> {
+    // TODO must this exist?
+}

--- a/src/main/groovy/com/groovycoder/spockdockerextension/Expose.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/Expose.groovy
@@ -13,7 +13,7 @@ package com.groovycoder.spockdockerextension
     int port()
 
     /**
-     * @return name under which the container is accessible inside the tests (optional)
+     * @return the referenced instance, defaults to 1
      */
     int instance() default 1
 }

--- a/src/main/groovy/com/groovycoder/spockdockerextension/Expose.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/Expose.groovy
@@ -1,0 +1,19 @@
+package com.groovycoder.spockdockerextension
+
+@interface Expose {
+
+    /**
+     * @return name of the image to start.
+     */
+    String service()
+
+    /**
+     * @return port bindings in docker CLI style syntax
+     */
+    int port()
+
+    /**
+     * @return name under which the container is accessible inside the tests (optional)
+     */
+    int instance() default 1
+}

--- a/src/main/groovy/com/groovycoder/spockdockerextension/ExposedServiceInstance.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/ExposedServiceInstance.groovy
@@ -1,0 +1,33 @@
+package com.groovycoder.spockdockerextension
+
+/**
+ * Reference to a single instance of a service.
+ *
+ * This class contains the same data as {@link Expose} but is easier to instantiate.
+ */
+class ExposedServiceInstance {
+    /**
+     * Name of the service.
+     */
+    String service
+
+    /**
+     * Internal port of the service
+     */
+    int port
+
+    /**
+     * The instance of the service
+     */
+    int instance
+
+    ExposedServiceInstance(String service, int port) {
+        this(service, port, 1)
+    }
+
+    ExposedServiceInstance(String service, int port, int instance) {
+        this.service = service
+        this.port = port
+        this.instance = instance
+    }
+}

--- a/src/main/groovy/com/groovycoder/spockdockerextension/docker/DockerComposeFacade.groovy
+++ b/src/main/groovy/com/groovycoder/spockdockerextension/docker/DockerComposeFacade.groovy
@@ -1,22 +1,60 @@
 package com.groovycoder.spockdockerextension.docker
 
+import com.groovycoder.spockdockerextension.ExposedServiceInstance
 import org.testcontainers.containers.DockerComposeContainer
 
 class DockerComposeFacade {
 
     String composeFile
     DockerComposeContainer dockerComposeContainer
+    Collection<ExposedServiceInstance> exposedServiceInstances
 
     DockerComposeFacade(String composeFile) {
+        this(composeFile, Collections.emptyList())
+    }
+
+    DockerComposeFacade(String composeFile, Collection<ExposedServiceInstance> exposedServiceInstances) {
         this.composeFile = composeFile
+        this.exposedServiceInstances = exposedServiceInstances.asImmutable()
     }
 
     void up() {
         dockerComposeContainer = new DockerComposeContainer(new File(composeFile))
+        exposedServiceInstances.each {
+            dockerComposeContainer.withExposedService(it.service, it.instance, it.port)
+        }
         dockerComposeContainer.starting(null)
     }
 
     void down() {
         dockerComposeContainer.finished(null)
+    }
+
+    def getServiceHost(String serviceName, int port) {
+        if (!serviceName.matches(".*_[0-9]+")) {
+            return getServiceHost(serviceName, port, 1)
+        }
+        return dockerComposeContainer.getServiceHost(serviceName, port)
+    }
+
+    def getServiceHost(String serviceName, int port, int instance) {
+        if (!serviceName.matches(".*_[0-9]+")) {
+            serviceName += "_$instance"
+        }
+        return dockerComposeContainer.getServiceHost(serviceName, port)
+    }
+
+    def getServicePort(String serviceName, int port) {
+        if (!serviceName.matches(".*_[0-9]+")) {
+            return getServicePort(serviceName, port, 1)
+        }
+        return dockerComposeContainer.getServiceHost(serviceName, port)
+    }
+
+    def getServicePort(String serviceName, int port, int instance) {
+        if (!serviceName.matches(".*_[0-9]+")) {
+            serviceName += "_$instance"
+        }
+        return dockerComposeContainer.getServicePort(serviceName, port)
     }
 }

--- a/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeFeatureAnnotationIT.groovy
+++ b/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeFeatureAnnotationIT.groovy
@@ -9,7 +9,7 @@ import spock.lang.Stepwise
 @Stepwise
 class DockerComposeFeatureAnnotationIT extends Specification {
 
-    @DockerCompose("src/test/resources/docker-compose.yml")
+    @DockerCompose(composeFile = "src/test/resources/docker-compose.yml")
     def "running compose defined container is accessible on configured port"() {
         given: "a http client"
         def client = HttpClientBuilder.create().build()

--- a/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeFieldAnnotationForFeatureAnnotationIT.groovy
+++ b/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeFieldAnnotationForFeatureAnnotationIT.groovy
@@ -1,0 +1,68 @@
+package com.groovycoder.spockdockerextension
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DockerComposeFieldAnnotationForFeatureAnnotationIT extends Specification {
+
+    @Shared
+    @DockerComposeServiceHost(service = "whoami", port = 80)
+    String sharedWhoamiHost
+
+    @Shared
+    @DockerComposeServicePort(service = "whoami", port = 80)
+    Integer sharedWhoamiPort
+
+    @DockerComposeServiceHost(service = "whoami", port = 80)
+    String whoamiHost
+
+    @DockerComposeServicePort(service = "whoami", port = 80)
+    Integer whoamiPort
+
+    @DockerCompose(composeFile = "src/test/resources/docker-compose.yml", exposedServicePorts =
+            [
+                    @Expose(service = "whoami", port = 80)
+            ])
+    def "shared host is injected"() {
+        expect:
+        sharedWhoamiHost != null
+    }
+
+    @DockerCompose(composeFile = "src/test/resources/docker-compose.yml", exposedServicePorts =
+            [
+                    @Expose(service = "whoami", port = 80)
+            ])
+    def "shared port is injected"() {
+        expect:
+        sharedWhoamiPort != null
+    }
+
+    @DockerCompose(composeFile = "src/test/resources/docker-compose.yml", exposedServicePorts =
+            [
+                    @Expose(service = "whoami", port = 80)
+            ])
+    def "host is injected"() {
+        expect:
+        whoamiHost != null
+    }
+
+    @DockerCompose(composeFile = "src/test/resources/docker-compose.yml", exposedServicePorts =
+            [
+                    @Expose(service = "whoami", port = 80)
+            ])
+    def "port is injected"() {
+        expect:
+        whoamiPort != null
+    }
+
+    def "host is not injected"() {
+        expect:
+        sharedWhoamiHost == null
+    }
+
+    def "port is not injected"() {
+        expect:
+        sharedWhoamiPort == null
+    }
+
+}

--- a/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeFieldAnnotationForFeatureAnnotationIT.groovy
+++ b/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeFieldAnnotationForFeatureAnnotationIT.groovy
@@ -23,24 +23,24 @@ class DockerComposeFieldAnnotationForFeatureAnnotationIT extends Specification {
             [
                     @Expose(service = "whoami", port = 80)
             ])
-    def "shared host is injected"() {
+    def "shared host is not injected when docker compose annotation is present"() {
         expect:
-        sharedWhoamiHost != null
+        sharedWhoamiHost == null
     }
 
     @DockerCompose(composeFile = "src/test/resources/docker-compose.yml", exposedServicePorts =
             [
                     @Expose(service = "whoami", port = 80)
             ])
-    def "shared port is injected"() {
+    def "shared port is not injected when docker compose annotation is present"() {
         expect:
-        sharedWhoamiPort != null
+        sharedWhoamiPort == null
     }
 
     @DockerCompose(composeFile = "src/test/resources/docker-compose.yml", exposedServicePorts =
             [
                     @Expose(service = "whoami", port = 80)
-            ])
+            ], shared = false)
     def "host is injected"() {
         expect:
         whoamiHost != null
@@ -55,14 +55,24 @@ class DockerComposeFieldAnnotationForFeatureAnnotationIT extends Specification {
         whoamiPort != null
     }
 
-    def "host is not injected"() {
+    def "shared host is not injected"() {
         expect:
         sharedWhoamiHost == null
     }
 
-    def "port is not injected"() {
+    def "shared port is not injected"() {
         expect:
         sharedWhoamiPort == null
+    }
+
+    def "host is not injected"() {
+        expect:
+        whoamiHost == null
+    }
+
+    def "port is not injected"() {
+        expect:
+        whoamiPort == null
     }
 
 }

--- a/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeFieldAnnotationIT.groovy
+++ b/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeFieldAnnotationIT.groovy
@@ -1,0 +1,45 @@
+package com.groovycoder.spockdockerextension
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+@DockerCompose(composeFile = "src/test/resources/docker-compose.yml", exposedServicePorts =
+        [
+                @Expose(service = "whoami", port = 80)
+        ], shared = false)
+class DockerComposeFieldAnnotationIT extends Specification {
+
+    @Shared
+    @DockerComposeServiceHost(service = "whoami", port = 80)
+    String sharedWhoamiHost
+
+    @Shared
+    @DockerComposeServicePort(service = "whoami", port = 80)
+    Integer sharedWhoamiPort
+
+    @DockerComposeServiceHost(service = "whoami", port = 80)
+    String whoamiHost
+
+    @DockerComposeServicePort(service = "whoami", port = 80)
+    Integer whoamiPort
+
+    def "shared host is not injected"() {
+        expect:
+        sharedWhoamiHost == null
+    }
+
+    def "shared port is not injected"() {
+        expect:
+        sharedWhoamiPort == null
+    }
+
+    def "instance host is injected"() {
+        expect:
+        whoamiHost != null
+    }
+
+    def "instance port is injected"() {
+        expect:
+        whoamiPort != null
+    }
+}

--- a/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeSharedFieldAnnotationIT.groovy
+++ b/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeSharedFieldAnnotationIT.groovy
@@ -1,0 +1,45 @@
+package com.groovycoder.spockdockerextension
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+@DockerCompose(composeFile = "src/test/resources/docker-compose.yml", exposedServicePorts =
+        [
+                @Expose(service = "whoami", port = 80)
+        ], shared = true)
+class DockerComposeSharedFieldAnnotationIT extends Specification {
+
+    @Shared
+    @DockerComposeServiceHost(service = "whoami", port = 80)
+    String sharedWhoamiHost
+
+    @Shared
+    @DockerComposeServicePort(service = "whoami", port = 80)
+    Integer sharedWhoamiPort
+
+    @DockerComposeServiceHost(service = "whoami", port = 80)
+    String whoamiHost
+
+    @DockerComposeServicePort(service = "whoami", port = 80)
+    Integer whoamiPort
+
+    def "shared host is injected"() {
+        expect:
+        sharedWhoamiHost != null
+    }
+
+    def "shared port is injected"() {
+        expect:
+        sharedWhoamiPort != null
+    }
+
+    def "instance host is not injected"() {
+        expect:
+        whoamiHost == null
+    }
+
+    def "instance port is not injected"() {
+        expect:
+        whoamiPort == null
+    }
+}

--- a/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeSpecAnnotationIT.groovy
+++ b/src/test/groovy/com/groovycoder/spockdockerextension/DockerComposeSpecAnnotationIT.groovy
@@ -38,7 +38,6 @@ class DockerComposeSpecAnnotationIT extends Specification {
     def "instance docker compose facade injected into spec"() {
         expect:
         instanceDockerComposeFacade != null
-        instanceDockerComposeFacade.dockerComposeContainer.getServiceHost("whoami_1", 80) != null
     }
 
     def "shared docker compose facade not injected into spec"() {
@@ -85,7 +84,7 @@ class DockerComposeSpecAnnotationIT extends Specification {
 
 
     @Unroll
-    def "docker compose is restarted between executions (#execution) in not shared mode"() {
+    def "docker compose is restarted between executions (#execution) in isolated mode (shared = false)"() {
         given:
         def host = instanceDockerComposeFacade.getServiceHost("whoami", 80)
         def port = instanceDockerComposeFacade.getServicePort("whoami", 80)

--- a/src/test/resources/docker-compose-uptime.yml
+++ b/src/test/resources/docker-compose-uptime.yml
@@ -1,5 +1,8 @@
 version: '2'
 services:
+  uptime:
+    image: usman/docker-uptime
+
   whoami:
     image: emilevauge/whoami
     ports:


### PR DESCRIPTION
 * DockerCompose allows to specify exposed services
 * DockerCompose mimics @Shared behavior: start once and stay up till end of spec, when shared = true, otherwise restart between features
 * Field annotations DockerComposeServiceHost / DockerComposeServicePort inject host / ip (also @Shared aware)